### PR TITLE
fix: 1873 Does not cleanup

### DIFF
--- a/pkg/fwdport/fwdport.go
+++ b/pkg/fwdport/fwdport.go
@@ -229,12 +229,12 @@ func PortForward(pfo *PortForwardOpts) error {
 	// Blocking call
 	if err = pfo.PortForwardHelper.ForwardPorts(fw); err != nil {
 		log.Errorf("ForwardPorts error: %s", err.Error())
-		//pfo.shutdown()
-		pfo.Stop()
+		pfo.shutdown()
+		//pfo.Stop()
 		return err
 	} else {
-		//pfo.shutdown()
-		pfo.Stop() // Don't shut down, this gives connected clients time to move to a new pod.
+		pfo.shutdown()
+		//pfo.Stop() // Don't shut down, this gives connected clients time to move to a new pod.
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Modified fwdport.go lines 230-238 to call shutdown instead of stop. The call is ambiguous with pods restarting or stopping and kubefwd shutting down.

Fixes #1873. in the mono-repo

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Technical improvement or removal of technical debt. 
- [ ] Minor change: comments, documentation, trivial fixes

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Unit Tests

Optional:

- [ ] Functional Tests
- [ ] Integration Tests

